### PR TITLE
Fix the abnormality caused by deleting sessionKey when processing KCP CONV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /build
 /vendor
+/frontend
 
 /data/proto
 /data/packetIds.json

--- a/frontend_server.go
+++ b/frontend_server.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"embed"
-	"github.com/gin-gonic/contrib/static"
-	"github.com/gin-gonic/gin"
 	"io"
 	"io/fs"
 	"log"
 	"net/http"
 	"os"
+
+	"github.com/gin-gonic/contrib/static"
+	"github.com/gin-gonic/gin"
 )
 
 var eventStream = make(chan string)


### PR DESCRIPTION
Put the newly generated key into initialKey. If the key is not obtained, then do not proceed with the subsequent processing.